### PR TITLE
fix: Make Extra a byte slice

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -43,13 +43,6 @@ type readCloseResetter interface {
 	flate.Resetter
 }
 
-// Extra encapsulates an EXTRA data field.
-type Extra struct {
-	SI1  byte
-	SI2  byte
-	Data []byte
-}
-
 // Header is the gzip file header.
 //
 // Strings must be UTF-8 encoded and may only contain Unicode code points
@@ -59,7 +52,7 @@ type Header struct {
 	Comment string
 
 	// Extra is the EXTRA data field.
-	Extra []*Extra
+	Extra []byte
 
 	// ModTime is the MTIME modification time field.
 	ModTime time.Time
@@ -328,6 +321,7 @@ func (z *Reader) readExtra() (int, int64, []int64, error) {
 	if err != nil {
 		return totalRead, 0, nil, fmt.Errorf("reading EXTRA: %w", err)
 	}
+	z.Extra = extra
 	z.digest.Write(extra)
 
 	// NOTE: The EXTRA field could could contain multiple sub-fields.
@@ -369,8 +363,6 @@ func (z *Reader) readExtra() (int, int64, []int64, error) {
 	if !foundRAField {
 		return totalRead, 0, nil, fmt.Errorf("%w: no RA EXTRA field", ErrHeader)
 	}
-
-	// TODO: Set z.Extra field.
 
 	return totalRead, chunkSize, sizes, nil
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -34,6 +34,7 @@ func TestReader(t *testing.T) {
 		fname     string
 		fcomment  string
 		os        byte
+		extra     []byte
 		chunkSize int64
 		offsets   []int64
 		bytes     []byte
@@ -71,9 +72,16 @@ func TestReader(t *testing.T) {
 				0x0, 0x0, 0x0, 0x0, // ISIZE
 			},
 
-			fname:     "empty.txt",
-			bytes:     []byte{},
-			os:        0x3,
+			fname: "empty.txt",
+			bytes: []byte{},
+			os:    0x3,
+			extra: []byte{
+				0x52, 0x41, // 'R', 'A'
+				0x6, 0x0, // LEN // 6
+				0x1, 0x0, // VER // 1
+				0xcb, 0xe3, // CHLEN // 58315
+				0x0, 0x0, // CHCNT // 0
+			},
 			chunkSize: 58315,
 			offsets:   []int64{32},
 		},
@@ -105,9 +113,16 @@ func TestReader(t *testing.T) {
 				0x0, 0x0, 0x0, 0x0, // CRC32
 				0x0, 0x0, 0x0, 0x0, // ISIZE
 			},
-			fcomment:  "fcomment.txt",
-			bytes:     []byte{},
-			os:        0x3,
+			fcomment: "fcomment.txt",
+			bytes:    []byte{},
+			os:       0x3,
+			extra: []byte{
+				0x52, 0x41, // 'R', 'A'
+				0x6, 0x0, // LEN = 6
+				0x1, 0x0, // VER = 1
+				0xcb, 0xe3, // CHLEN = 58315
+				0x0, 0x0, // CHCNT = 0
+			},
 			chunkSize: 58315,
 			offsets:   []int64{35},
 		},
@@ -138,8 +153,15 @@ func TestReader(t *testing.T) {
 				0x0, 0x0, 0x0, 0x0, // CRC32
 				0x0, 0x0, 0x0, 0x0, // ISIZE
 			},
-			bytes:     []byte{},
-			os:        0x3,
+			bytes: []byte{},
+			os:    0x3,
+			extra: []byte{
+				0x52, 0x41, // 'R', 'A'
+				0x6, 0x0, // LEN // 6
+				0x1, 0x0, // VER // 1
+				0xcb, 0xe3, // CHLEN // 58315
+				0x0, 0x0, // CHCNT // 0
+			},
 			chunkSize: 58315,
 			offsets:   []int64{24},
 		},
@@ -198,6 +220,10 @@ func TestReader(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.os, z.OS); diff != "" {
+				t.Errorf("OS (-want, +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.extra, z.Extra); diff != "" {
 				t.Errorf("OS (-want, +got):\n%s", diff)
 			}
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Make `Extra` a byte slice.

**Related Issues:**

Fixes #14 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
