### PR TITLE
feat: add compression to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - An `io.Writer` implementation was added for writing dictzip files.
+- The `dictzip` command now supports compression.
 
 ## [0.1.0] - 2024-11-09
 

--- a/cmd/dictzip/compress.go
+++ b/cmd/dictzip/compress.go
@@ -1,0 +1,88 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ianlewis/go-dictzip"
+)
+
+type compress struct {
+	path   string
+	force  bool
+	noName bool
+	keep   bool
+}
+
+func (c *compress) Run() error {
+	newPath := c.path + ".dz"
+
+	from, err := os.Open(c.path)
+	if err != nil {
+		return fmt.Errorf("%w: opening file: %w", ErrDictzip, err)
+	}
+	defer from.Close()
+
+	var fName string
+	var modTime time.Time
+	if !c.noName {
+		var fInfo os.FileInfo
+		fInfo, err = from.Stat()
+		if err != nil {
+			return fmt.Errorf("%w: stat %q: %w", ErrDictzip, from.Name(), err)
+		}
+		modTime = fInfo.ModTime()
+		fName = filepath.Base(from.Name())
+	}
+
+	flags := os.O_CREATE | os.O_WRONLY
+	if !c.force {
+		// Do not overwrite existing files unless --force is specified.
+		flags |= os.O_EXCL
+	}
+
+	dst, err := os.OpenFile(newPath, flags, 0o644)
+	if err != nil {
+		return fmt.Errorf("%w: opening target file: %w", ErrDictzip, err)
+	}
+	defer dst.Close()
+
+	z, err := dictzip.NewWriter(dst)
+	if err != nil {
+		return fmt.Errorf("%w: creating writer: %w", ErrDictzip, err)
+	}
+	z.ModTime = modTime
+	z.Name = fName
+	defer z.Close()
+
+	_, err = io.Copy(z, from)
+	if err != nil {
+		return fmt.Errorf("%w: decompressing file %q: %w", ErrDictzip, from.Name(), err)
+	}
+
+	if !c.keep {
+		err = os.Remove(c.path)
+		if err != nil {
+			return fmt.Errorf("%w: removing file: %w", ErrDictzip, err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/dictzip/license.go
+++ b/cmd/dictzip/license.go
@@ -1,0 +1,57 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+	"sigs.k8s.io/release-utils/version"
+)
+
+func printVersion(c *cli.Context) error {
+	versionInfo := version.GetVersionInfo()
+	_, err := fmt.Fprintf(c.App.Writer, `%s %s
+Copyright 2024 Google LLC
+
+%s
+`, c.App.Name, versionInfo.GitVersion, versionInfo.String())
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrDictzip, err)
+	}
+	return nil
+}
+
+func printLicense(c *cli.Context) error {
+	err := printVersion(c)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(c.App.Writer, `    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+         http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.`)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrDictzip, err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Adds compression support to the `dictzip` command. Also adds the `--license` command and updates `--version` command.

**Related Issues:**

Updates #13 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
