### PR TITLE
fix: reading across chunks

### DIFF
--- a/cmd/dictzip/list.go
+++ b/cmd/dictzip/list.go
@@ -45,14 +45,8 @@ func (l *list) Run() error {
 	if err != nil {
 		return fmt.Errorf("%w: stat: %w", ErrDictzip, err)
 	}
+
 	compressed := fInfo.Size()
-
-	// sizes := z.Sizes()
-	// var compressed int64
-	// for _, size := range sizes {
-	// 	compressed += int64(size)
-	// }
-
 	uncompressed, err := io.Copy(io.Discard, z)
 	if err != nil {
 		return fmt.Errorf("%w: reading archive: %w", ErrDictzip, err)

--- a/reader_test.go
+++ b/reader_test.go
@@ -72,16 +72,9 @@ func TestReader(t *testing.T) {
 				0x0, 0x0, 0x0, 0x0, // ISIZE
 			},
 
-			fname: "empty.txt",
-			bytes: []byte{},
-			os:    0x3,
-			extra: []byte{
-				0x52, 0x41, // 'R', 'A'
-				0x6, 0x0, // LEN // 6
-				0x1, 0x0, // VER // 1
-				0xcb, 0xe3, // CHLEN // 58315
-				0x0, 0x0, // CHCNT // 0
-			},
+			fname:     "empty.txt",
+			bytes:     []byte{},
+			os:        0x3,
 			chunkSize: 58315,
 			offsets:   []int64{32},
 		},
@@ -113,18 +106,52 @@ func TestReader(t *testing.T) {
 				0x0, 0x0, 0x0, 0x0, // CRC32
 				0x0, 0x0, 0x0, 0x0, // ISIZE
 			},
-			fcomment: "fcomment.txt",
-			bytes:    []byte{},
-			os:       0x3,
-			extra: []byte{
-				0x52, 0x41, // 'R', 'A'
-				0x6, 0x0, // LEN = 6
-				0x1, 0x0, // VER = 1
-				0xcb, 0xe3, // CHLEN = 58315
-				0x0, 0x0, // CHCNT = 0
-			},
+			fcomment:  "fcomment.txt",
+			bytes:     []byte{},
+			os:        0x3,
 			chunkSize: 58315,
 			offsets:   []int64{35},
+		},
+		{
+			name: "with extra",
+			data: []byte{
+				// Header
+				hdrGzipID1,
+				hdrGzipID2,
+				hdrDeflateCM,
+				flgEXTRA,               // FLG
+				0x00, 0x00, 0x00, 0x00, // MTIME
+				0x0,       // XFL
+				OSUnknown, // OS
+
+				// EXTRA
+				0x11, 0x0, // XLEN // 17
+				0x52, 0x41, // 'R', 'A'
+				0x6, 0x0, // LEN // 6
+				0x1, 0x0, // VER // 1
+				0xff, 0xff, // CHLEN // 65535
+				0x0, 0x0, // CHCNT // 0
+
+				// User-specified EXTRA sub-field.
+				'A', 'Z', // SI
+				0x3, 0x0, // LEN
+				0xab, 0xcd, 0xef,
+
+				0x01, 0x00, 0x00, 0xff, 0xff, // Empty deflate data (sync/end marker)
+
+				0x0, 0x0, 0x0, 0x0, // CRC32
+				0x0, 0x0, 0x0, 0x0, // ISIZE
+			},
+
+			extra: []byte{
+				'A', 'Z', // SI
+				0x3, 0x0, // LEN
+				0xab, 0xcd, 0xef,
+			},
+			bytes:     []byte{},
+			os:        OSUnknown,
+			chunkSize: DefaultChunkSize,
+			offsets:   []int64{29},
 		},
 		{
 			name: "with crc16",
@@ -153,15 +180,8 @@ func TestReader(t *testing.T) {
 				0x0, 0x0, 0x0, 0x0, // CRC32
 				0x0, 0x0, 0x0, 0x0, // ISIZE
 			},
-			bytes: []byte{},
-			os:    0x3,
-			extra: []byte{
-				0x52, 0x41, // 'R', 'A'
-				0x6, 0x0, // LEN // 6
-				0x1, 0x0, // VER // 1
-				0xcb, 0xe3, // CHLEN // 58315
-				0x0, 0x0, // CHCNT // 0
-			},
+			bytes:     []byte{},
+			os:        0x3,
 			chunkSize: 58315,
 			offsets:   []int64{24},
 		},
@@ -195,6 +215,49 @@ func TestReader(t *testing.T) {
 			bytes:  []byte{},
 			newErr: ErrHeader,
 		},
+		{
+			name: "multi-chunk",
+			data: []byte{
+				// Header
+				hdrGzipID1,
+				hdrGzipID2,
+				hdrDeflateCM,
+				flgEXTRA,               // FLG
+				0x00, 0x00, 0x00, 0x00, // MTIME
+				0x0,       // XFL
+				OSUnknown, // OS
+
+				// EXTRA
+				0x12, 0x0, // XLEN // 18
+				0x52, 0x41, // 'R', 'A'
+				0xe, 0x0, // LEN // 14
+				0x1, 0x0, // VER // 1
+				0x6, 0x0, // CHLEN // 65535
+				0x4, 0x0, // CHCNT // 4
+
+				// Chunk sizes.
+				0xc, 0x0, // 12
+				0xc, 0x0, // 12
+				0xc, 0x0, // 12
+				0xc, 0x0, // 12
+
+				// compressed data (4 chunks of 12 bytes each).
+				0x4a, 0xce, 0x28, 0xcd, 0xcb, 0x36, 0x04, 0x00, 0x00, 0x00, 0xff, 0xff,
+				0x4a, 0xce, 0x28, 0xcd, 0xcb, 0x36, 0x02, 0x00, 0x00, 0x00, 0xff, 0xff,
+				0x4a, 0xce, 0x28, 0xcd, 0xcb, 0x36, 0x06, 0x00, 0x00, 0x00, 0xff, 0xff,
+				0x4a, 0xce, 0x28, 0xcd, 0xcb, 0x36, 0x01, 0x00, 0x00, 0x00, 0xff, 0xff,
+
+				0x01, 0x00, 0x00, 0xff, 0xff, // sync/end marker.
+
+				0x85, 0x42, 0x75, 0x46, // CRC-32
+				0x18, 0x00, 0x00, 0x00, // ISIZE // 24 (len of data)
+			},
+
+			os:        OSUnknown,
+			chunkSize: 6,
+			bytes:     []byte("chunk1chunk2chunk3chunk4"),
+			offsets:   []int64{30, 42, 54, 66, 78},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -224,7 +287,7 @@ func TestReader(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.extra, z.Extra); diff != "" {
-				t.Errorf("OS (-want, +got):\n%s", diff)
+				t.Errorf("Extra (-want, +got):\n%s", diff)
 			}
 
 			if diff := cmp.Diff(tc.chunkSize, z.ChunkSize()); diff != "" {
@@ -301,6 +364,90 @@ func TestReader_Read(t *testing.T) {
 
 	// r.offset should should be advanced by the # of read bytes.
 	if diff := cmp.Diff(int64(25), r.offset); diff != "" {
+		t.Errorf("r.offset (-want, +got):\n%s", diff)
+	}
+}
+
+func TestReader_Read_multiblock(t *testing.T) {
+	t.Parallel()
+
+	z, err := NewReader(bytes.NewReader([]byte{
+		// Header
+		hdrGzipID1,
+		hdrGzipID2,
+		hdrDeflateCM,
+		flgEXTRA,               // FLG
+		0x00, 0x00, 0x00, 0x00, // MTIME
+		0x0,       // XFL
+		OSUnknown, // OS
+
+		// EXTRA
+		0x12, 0x0, // XLEN // 18
+		0x52, 0x41, // 'R', 'A'
+		0xe, 0x0, // LEN // 14
+		0x1, 0x0, // VER // 1
+		0x6, 0x0, // CHLEN // 65535
+		0x4, 0x0, // CHCNT // 4
+
+		// Chunk sizes.
+		0xc, 0x0, // 12
+		0xc, 0x0, // 12
+		0xc, 0x0, // 12
+		0xc, 0x0, // 12
+
+		// compressed data (4 chunks of 12 bytes each).
+		0x4a, 0xce, 0x28, 0xcd, 0xcb, 0x36, 0x04, 0x00, 0x00, 0x00, 0xff, 0xff,
+		0x4a, 0xce, 0x28, 0xcd, 0xcb, 0x36, 0x02, 0x00, 0x00, 0x00, 0xff, 0xff,
+		0x4a, 0xce, 0x28, 0xcd, 0xcb, 0x36, 0x06, 0x00, 0x00, 0x00, 0xff, 0xff,
+		0x4a, 0xce, 0x28, 0xcd, 0xcb, 0x36, 0x01, 0x00, 0x00, 0x00, 0xff, 0xff,
+
+		0x01, 0x00, 0x00, 0xff, 0xff, // sync/end marker.
+
+		0x85, 0x42, 0x75, 0x46, // CRC-32
+		0x18, 0x00, 0x00, 0x00, // ISIZE // 24 (len of data)
+	}))
+	if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
+		t.Fatalf("NewReader (-want, +got):\n%s", diff)
+	}
+
+	// Each chunk is 6 bytes long. Request more than 1 chunk of data.
+	buf := make([]byte, 9)
+	n, err := z.Read(buf)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	if diff := cmp.Diff(9, n); diff != "" {
+		t.Errorf("Read (-want, +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff([]byte("chunk1chu"), buf); diff != "" {
+		t.Errorf("Read (-want, +got):\n%s", diff)
+	}
+
+	// r.offset should should be advanced by the # of read bytes.
+	if diff := cmp.Diff(int64(9), z.offset); diff != "" {
+		t.Errorf("r.offset (-want, +got):\n%s", diff)
+	}
+
+	// The next read reads starting at the third byte of the second chunk.
+	// It reads less than 1 chunk worth of bytes but across a chunk boundary.
+	buf2 := make([]byte, 5)
+	n2, err := z.Read(buf2)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	if diff := cmp.Diff(5, n2); diff != "" {
+		t.Errorf("Read (-want, +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff([]byte("nk2ch"), buf2); diff != "" {
+		t.Errorf("Read (-want, +got):\n%s", diff)
+	}
+
+	// r.offset should should be advanced by the # of read bytes.
+	if diff := cmp.Diff(int64(14), z.offset); diff != "" {
 		t.Errorf("r.offset (-want, +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
**Description:**

Fixes a bug where the bytes requested span a chunk but are less than a single chunk in length.

**Related Issues:**

Fixes #27 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
