### PR TITLE
feat: add --start and --size flags

### DIFF
--- a/cmd/dictzip/app.go
+++ b/cmd/dictzip/app.go
@@ -205,11 +205,6 @@ func newDictzipApp() *cli.App {
 				}
 			}
 
-			// If --start or --size are specified --decompress is implied.
-			if c.IsSet("start") || c.IsSet("size") {
-				c.Set("decompress", "true")
-			}
-
 			// decompress
 			if c.Bool("decompress") {
 				return decompressCmd(c)

--- a/cmd/dictzip/app.go
+++ b/cmd/dictzip/app.go
@@ -195,15 +195,7 @@ func newDictzipApp() *cli.App {
 			}
 
 			if c.Bool("list") || c.Bool("test") {
-				for _, path := range c.Args().Slice() {
-					l := list{
-						path: path,
-					}
-					if err := l.Run(); err != nil {
-						return err
-					}
-				}
-				return nil
+				return listCmd(c)
 			}
 
 			// If --start or --size are specified --decompress is implied.
@@ -215,45 +207,11 @@ func newDictzipApp() *cli.App {
 
 			// decompress
 			if c.Bool("decompress") {
-				// If --stdout is specified, --keep is implied.
-				if c.Bool("stdout") {
-					if err := c.Set("keep", "true"); err != nil {
-						return fmt.Errorf("%w: internal error: %w", ErrDictzip, err)
-					}
-				}
-
-				for _, path := range c.Args().Slice() {
-					d := decompress{
-						path:    path,
-						force:   c.Bool("force"),
-						keep:    c.Bool("keep"),
-						stdout:  c.Bool("stdout"),
-						verbose: c.Bool("verbose"),
-						start:   c.Int64("start"),
-						size:    c.Int64("size"),
-					}
-					if err := d.Run(); err != nil {
-						return err
-					}
-				}
-				return nil
+				return decompressCmd(c)
 			}
 
 			// compress
-			for _, path := range c.Args().Slice() {
-				// compress
-				c := compress{
-					path:    path,
-					force:   c.Bool("force"),
-					noName:  c.Bool("no-name"),
-					keep:    c.Bool("keep"),
-					verbose: c.Bool("verbose"),
-				}
-				if err := c.Run(); err != nil {
-					return err
-				}
-			}
-			return nil
+			return compressCmd(c)
 		},
 		ExitErrHandler: func(c *cli.Context, err error) {
 			if err == nil {
@@ -270,4 +228,57 @@ func newDictzipApp() *cli.App {
 			cli.OsExiter(ExitCodeUnknownError)
 		},
 	}
+}
+
+func listCmd(c *cli.Context) error {
+	for _, path := range c.Args().Slice() {
+		l := list{
+			path: path,
+		}
+		if err := l.Run(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func compressCmd(c *cli.Context) error {
+	for _, path := range c.Args().Slice() {
+		c := compress{
+			path:    path,
+			force:   c.Bool("force"),
+			noName:  c.Bool("no-name"),
+			keep:    c.Bool("keep"),
+			verbose: c.Bool("verbose"),
+		}
+		if err := c.Run(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func decompressCmd(c *cli.Context) error {
+	// If --stdout is specified, --keep is implied.
+	if c.Bool("stdout") {
+		if err := c.Set("keep", "true"); err != nil {
+			return fmt.Errorf("%w: internal error: %w", ErrDictzip, err)
+		}
+	}
+
+	for _, path := range c.Args().Slice() {
+		d := decompress{
+			path:    path,
+			force:   c.Bool("force"),
+			keep:    c.Bool("keep"),
+			stdout:  c.Bool("stdout"),
+			verbose: c.Bool("verbose"),
+			start:   c.Int64("start"),
+			size:    c.Int64("size"),
+		}
+		if err := d.Run(); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/dictzip/app.go
+++ b/cmd/dictzip/app.go
@@ -208,14 +208,18 @@ func newDictzipApp() *cli.App {
 
 			// If --start or --size are specified --decompress is implied.
 			if c.IsSet("start") || c.IsSet("size") {
-				c.Set("decompress", "true")
+				if err := c.Set("decompress", "true"); err != nil {
+					return fmt.Errorf("%w: internal error: %w", ErrDictzip, err)
+				}
 			}
 
 			// decompress
 			if c.Bool("decompress") {
 				// If --stdout is specified, --keep is implied.
 				if c.Bool("stdout") {
-					c.Set("keep", "true")
+					if err := c.Set("keep", "true"); err != nil {
+						return fmt.Errorf("%w: internal error: %w", ErrDictzip, err)
+					}
 				}
 
 				for _, path := range c.Args().Slice() {

--- a/cmd/dictzip/app.go
+++ b/cmd/dictzip/app.go
@@ -144,8 +144,19 @@ func newDictzipApp() *cli.App {
 
 			// NOTE: -D --debug flag is not supported.
 
-			// TODO(#13): -s --start <offset>  starting offset for decompression (decimal)
-			// TODO(#13): -e --size <offset>   size for decompression (decimal)
+			&cli.Int64Flag{
+				Name:    "start",
+				Usage:   "starting `offset` for decompression (decimal)",
+				Aliases: []string{"s"},
+				Value:   0,
+			},
+			&cli.Int64Flag{
+				Name:        "size",
+				Usage:       "`size` for decompression (decimal)",
+				Aliases:     []string{"e"},
+				DefaultText: "whole file",
+				Value:       -1,
+			},
 			// TODO(#13): -S --Start <offset>  starting offset for decompression (base64)
 			// TODO(#13): -E --Size <offset>   size for decompression (base64)
 			// TODO(#13): -p --pre <filter>    pre-compression filter
@@ -195,8 +206,18 @@ func newDictzipApp() *cli.App {
 				return nil
 			}
 
+			// If --start or --size are specified --decompress is implied.
+			if c.IsSet("start") || c.IsSet("size") {
+				c.Set("decompress", "true")
+			}
+
 			// decompress
 			if c.Bool("decompress") {
+				// If --stdout is specified, --keep is implied.
+				if c.Bool("stdout") {
+					c.Set("keep", "true")
+				}
+
 				for _, path := range c.Args().Slice() {
 					d := decompress{
 						path:    path,
@@ -204,6 +225,8 @@ func newDictzipApp() *cli.App {
 						keep:    c.Bool("keep"),
 						stdout:  c.Bool("stdout"),
 						verbose: c.Bool("verbose"),
+						start:   c.Int64("start"),
+						size:    c.Int64("size"),
 					}
 					if err := d.Run(); err != nil {
 						return err

--- a/cmd/dictzip/decompress.go
+++ b/cmd/dictzip/decompress.go
@@ -121,7 +121,7 @@ func (d *decompress) decompress(dst io.Writer, src *os.File) (n int64, sizes []i
 		return
 	}
 
-	if d.size != -1 {
+	if d.size < 0 {
 		n, err = io.CopyN(dst, z, d.size)
 	} else {
 		n, err = io.Copy(dst, z)

--- a/reader.go
+++ b/reader.go
@@ -264,6 +264,10 @@ func (z *Reader) Seek(offset int64, whence int) (int64, error) {
 // number of bytes advanced in the underlying reader and bytes read.
 func (z *Reader) readChunk(offset int64, size int) ([]byte, error) {
 	chunkNum := offset / int64(z.chunkSize)
+	if chunkNum >= int64(len(z.offsets)) {
+		// NOTE: We are trying to seek past the end of the file.
+		return nil, io.EOF
+	}
 	chunkOffset := z.offsets[chunkNum]
 
 	if _, err := z.r.Seek(chunkOffset, io.SeekStart); err != nil {

--- a/writer_test.go
+++ b/writer_test.go
@@ -358,7 +358,7 @@ func TestWriter(t *testing.T) {
 				0x52, 0x41, // 'R', 'A'
 				0xe, 0x0, // LEN // 14
 				0x1, 0x0, // VER // 1
-				0x6, 0x0, // CHLEN // 65535
+				0x6, 0x0, // CHLEN // 6
 				0x4, 0x0, // CHCNT // 4
 
 				// Chunk sizes.
@@ -404,7 +404,7 @@ func TestWriter(t *testing.T) {
 				0x52, 0x41, // 'R', 'A'
 				0xe, 0x0, // LEN // 14
 				0x1, 0x0, // VER // 1
-				0x6, 0x0, // CHLEN // 65535
+				0x6, 0x0, // CHLEN // 6
 				0x4, 0x0, // CHCNT // 4
 
 				// Chunk sizes.


### PR DESCRIPTION
**Description:**

Add `--start` and `--size` flags to the `dictzip` command.

**Related Issues:**

Updates #13 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
