### PR TITLE
fix: seeking past the EOF

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -264,6 +264,10 @@ func (z *Reader) Seek(offset int64, whence int) (int64, error) {
 // number of bytes advanced in the underlying reader and bytes read.
 func (z *Reader) readChunk(offset int64, size int) ([]byte, error) {
 	chunkNum := offset / int64(z.chunkSize)
+	if chunkNum >= int64(len(z.offsets)) {
+		// NOTE: We are trying to seek past the end of the file.
+		return nil, io.EOF
+	}
 	chunkOffset := z.offsets[chunkNum]
 
 	if _, err := z.r.Seek(chunkOffset, io.SeekStart); err != nil {

--- a/writer_test.go
+++ b/writer_test.go
@@ -358,7 +358,7 @@ func TestWriter(t *testing.T) {
 				0x52, 0x41, // 'R', 'A'
 				0xe, 0x0, // LEN // 14
 				0x1, 0x0, // VER // 1
-				0x6, 0x0, // CHLEN // 65535
+				0x6, 0x0, // CHLEN // 6
 				0x4, 0x0, // CHCNT // 4
 
 				// Chunk sizes.
@@ -404,7 +404,7 @@ func TestWriter(t *testing.T) {
 				0x52, 0x41, // 'R', 'A'
 				0xe, 0x0, // LEN // 14
 				0x1, 0x0, // VER // 1
-				0x6, 0x0, // CHLEN // 65535
+				0x6, 0x0, // CHLEN // 6
 				0x4, 0x0, // CHCNT // 4
 
 				// Chunk sizes.


### PR DESCRIPTION
**Description:**

Fixes a panic when attempting to seek past the last chunk of the file. The reader now returns `io.EOF`.

**Related Issues:**

Fixes #32 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
