### PR TITLE
chore: Update Go minimum version to 1.23

### DIFF
--- a/.github/workflows/pre-submit.units.yml
+++ b/.github/workflows/pre-submit.units.yml
@@ -1,4 +1,5 @@
 # Copyright 2023 Google LLC
+# Copyright 2025 Ian Lewis
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,10 +35,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.20"
-          - "1.21"
-          - "1.22"
           - "1.23"
+          - "1.24"
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     if: ${{ always() }}
@@ -157,8 +156,8 @@ jobs:
         with:
           go-version-file: "go.mod"
       - env:
-          GOLANGCI_LINT_VERSION: "1.61.0"
-          GOLANGCI_LINT_CHECKSUM: "77cb0af99379d9a21d5dc8c38364d060e864a01bd2f3e30b5e8cc550c3a54111"
+          GOLANGCI_LINT_VERSION: "1.64.5"
+          GOLANGCI_LINT_CHECKSUM: "e6bd399a0479c5fd846dcf9f3990d20448b4f0d1e5027d82348eab9f80f7ac71"
         run: |
           set -euo pipefail
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,13 +36,13 @@ linters:
   enable:
     - asciicheck
     - contextcheck
+    - copyloopvar
     - depguard
     - dogsled
     - err113
     - errcheck
     - errorlint
     - exhaustive
-    - exportloopref
     - gci
     - gochecknoinits
     - gocognit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to go-dictzip will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- The minimum supported Go version is now 1.23.
+
 ## [0.2.0] - 2024-11-17
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/ianlewis/go-dictzip
 
-go 1.20
+go 1.23.7
+
+toolchain go1.24.0
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/reader.go
+++ b/reader.go
@@ -179,6 +179,7 @@ type Reader struct {
 func NewReader(r io.ReadSeeker) (*Reader, error) {
 	fr := flate.NewReader(r)
 	z := &Reader{
+		//nolint:errcheck // flate.NewReader always returns an io.ReadCloser that implements flate.Resetter.
 		z: fr.(readCloseResetter),
 	}
 	if err := z.Reset(r); err != nil {

--- a/reader_test.go
+++ b/reader_test.go
@@ -261,8 +261,6 @@ func TestReader(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -478,8 +478,6 @@ func TestWriter(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
**Description:**

Bump the minimum supported version of Go to 1.23 since that's the minimum version supported by the Go team.

**Related Issues:**

Fixes #56

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
